### PR TITLE
Set xdebug use_compression to false

### DIFF
--- a/local/docker/wordpress/config/php/php.ini
+++ b/local/docker/wordpress/config/php/php.ini
@@ -13,7 +13,7 @@ xdebug.mode=off
 xdebug.scream=1
 xdebug.discover_client_host=1
 xdebug.start_with_request=trigger
-
+xdebug.use_compression=0
 [opcache]
 opcache.enable=1
 opcache.validate_timestamps=1

--- a/local/docker/wordpress/config/php/php.ini
+++ b/local/docker/wordpress/config/php/php.ini
@@ -14,6 +14,7 @@ xdebug.scream=1
 xdebug.discover_client_host=1
 xdebug.start_with_request=trigger
 xdebug.use_compression=0
+
 [opcache]
 opcache.enable=1
 opcache.validate_timestamps=1


### PR DESCRIPTION
- Set the `use_compression` param to false in order to prevent gzip compression on generated profiles and allow `Webgrind` to properly display the desired results.