### PR TITLE
Add script for new relic deployment markers

### DIFF
--- a/local/scripts/new-relic-deployment-markers.js
+++ b/local/scripts/new-relic-deployment-markers.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 // run this command with the following arguments:
 // -s, --search: The search term to use to find the entity GUIDs to create deployment markers for.
-// -a, --api_key: The API key to use to authenticate with New Relic.
+// -a, --api_key: The API key to use to authenticate with New Relic, follow the instructions here to create one: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key
 // -c, --commit: The commit hash to use for the deployment marker.
 // -u, --user: The user to use for the deployment marker.
 // -d, --description: The description to use for the deployment marker.

--- a/local/scripts/new-relic-deployment-markers.js
+++ b/local/scripts/new-relic-deployment-markers.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+// run this command with the following arguments:
+// -s, --search: The search term to use to find the entity GUIDs to create deployment markers for.
+// -a, --api_key: The API key to use to authenticate with New Relic.
+// -c, --commit: The commit hash to use for the deployment marker.
+// -u, --user: The user to use for the deployment marker.
+// -d, --description: The description to use for the deployment marker.
+// e.g. node new-relic-deployment-markers.js -s "my-site" -a "my-api-key" -c "my-commit-hash" -u "my-user" -d "my-description"
+
+const https = require( 'https' );
+const process = require( 'process' );
+
+// Parse command line arguments
+const args = process.argv.slice( 2 );
+let search, apiKey, commit, user, description;
+
+while ( args.length > 0 ) {
+	const key = args.shift();
+
+	switch ( key ) {
+		case '-s':
+		case '--search':
+			search = args.shift();
+			break;
+		case '-a':
+		case '--api_key':
+			apiKey = args.shift();
+			break;
+		case '-c':
+		case '--commit':
+			commit = args.shift();
+			break;
+		case '-u':
+		case '--user':
+			user = args.shift();
+			break;
+		case '-d':
+		case '--description':
+			description = args.shift();
+			break;
+		default:
+			// eslint-disable-next-line no-console
+			console.error( `Unknown option: ${ key }` );
+			process.exit( 1 );
+	}
+}
+
+if ( ! search ) {
+	// eslint-disable-next-line no-console
+	console.error( 'Missing required argument: --search' );
+	process.exit( 1 );
+}
+
+if ( ! apiKey ) {
+	// eslint-disable-next-line no-console
+	console.error( 'Missing required argument: --api_key' );
+	process.exit( 1 );
+}
+
+const searchQuery = {
+	query: `{
+    actor {
+      entitySearch(queryBuilder: {name: "*${ search }*"}) {
+        count
+        query
+        results {
+          entities {
+            name
+            guid
+          }
+        }
+      }
+    }
+  }`,
+	variables: '',
+};
+
+const searchRequestOptions = {
+	method: 'POST',
+	headers: {
+		'Content-Type': 'application/json',
+		'API-Key': apiKey,
+	},
+};
+
+const searchRequest = https.request( 'https://api.newrelic.com/graphql', searchRequestOptions, ( searchResponse ) => {
+	let responseBody = '';
+
+	searchResponse.on( 'data', ( chunk ) => {
+		responseBody += chunk;
+	} );
+
+	searchResponse.on( 'end', () => {
+		const guids = JSON.parse( responseBody ).data.actor.entitySearch.results.entities.map( ( entity ) => entity.guid );
+
+		// description is a commit message and can contain double quotes, new lines, which will break the GraphQL query.
+		description = description.replace( /"/g, '\\"' ).replace( /\n/g, '\\n' );
+
+		guids.forEach( ( guid ) => {
+			const timestamp = Date.now() + (120 * 1000); // Add two minutes to current timestamp to acocunt for difference between actual deployment from VIP.
+
+			const deploymentMarkerQuery = {
+				query: `mutation {
+          changeTrackingCreateDeployment(deployment: {version: "${ commit }", entityGuid: "${ guid }", timestamp: ${ timestamp }, commit: "${ commit }", user: "${ user }", description: "${ description }"}) {
+            changelog
+            commit
+            deepLink
+            deploymentId
+            deploymentType
+            description
+            groupId
+            user
+          }
+        }`,
+				variables: '',
+			};
+
+			const deploymentRequestOptions = {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'API-Key': apiKey,
+				},
+			};
+
+			const deploymentRequest = https.request( 'https://api.newrelic.com/graphql', deploymentRequestOptions, ( deploymentResponse ) => {
+				let deploymentResponseBody = '';
+
+				deploymentResponse.on( 'data', ( chunk ) => {
+					deploymentResponseBody += chunk;
+				} );
+
+				deploymentResponse.on( 'end', () => {
+					if ( deploymentResponse.statusCode >= 200 && deploymentResponse.statusCode < 300 ) {
+						console.log( `Creating deployment marker for ${ guid } was successful.` );
+						console.log( 'Response:', JSON.parse( deploymentResponseBody ) );
+					} else {
+						console.error( `Failed to create deployment marker for ${ guid }.` );
+						console.error( 'Error response:', JSON.parse( deploymentResponseBody ) );
+					}
+				} );
+			} );
+
+			deploymentRequest.write( JSON.stringify( deploymentMarkerQuery ) );
+			deploymentRequest.end();
+		} );
+	} );
+} );
+
+searchRequest.write( JSON.stringify( searchQuery ) );
+searchRequest.end();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"logs": "docker-compose logs --follow",
 		"setup": "npm run cli -- wp core multisite-install",
 		"deploy-staging": "./local/scripts/deploy.sh git@github.com:wpcomvip/devgo-vip.git develop",
-		"deploy-production": "./local/scripts/deploy.sh git@github.com:wpcomvip/devgo-vip.git master"
+		"deploy-production": "./local/scripts/deploy.sh git@github.com:wpcomvip/devgo-vip.git master",
+		"nr-deployment-marker": "node local/scripts/new-relic-deployment-markers.js"
 	},
 	"devDependencies": {
 		"@automattic/vip": "^2.26.2",

--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -63,3 +63,16 @@ if ( function_exists( 'newrelic_disable_autorum' ) ) {
 if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT && ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', true );
 }
+
+/**
+ * Set site domain for NewRelic in order to have separate logs for each site.
+ */
+if ( isset( $_SERVER['HTTP_HOST'] ) && function_exists( 'newrelic_set_appname' ) ) {
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- it is ok, the code is copied from docs: https://docs.wpvip.com/technical-references/new-relic-for-wordpress/#h-separate-apps-out-on-a-per-site-basis-for-multisite
+	$app_name = $_SERVER['HTTP_HOST'];
+	if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && ! empty( $app_name ) ) {
+		$app_name .= '-' . VIP_GO_APP_ENVIRONMENT;
+	}
+
+	newrelic_set_appname( $app_name );
+}


### PR DESCRIPTION
Update the new relic app name based on the domain name, this separates the requests for each sub-sites on the new relic.

This PR also adds a script to add deployment markers, This script can be run after the deployment has run

```shell
npm run nr-deployment-marker -- --search -develop --api_key ${{ secrets.NEW_RELIC_API_KEY }} --commit ${{ github.sha }} --user ${{ github.actor }} --description "$(git log -1 --pretty=%B)"
```


Documentation from new-relic can be followed to generate an API key - https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key