### PR TITLE
Use linux/arm64 for m1; Remove deprecated version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
 
   # Route HTTP requests to specific containers based on the HTTP_HOST header.
@@ -52,6 +50,7 @@ services:
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:5.2.1
+    platform: linux/amd64
     depends_on:
       - db
     environment:
@@ -74,6 +73,7 @@ services:
   # Review Xdebug profiling data.
   webgrind:
     image: jokkedk/webgrind:latest
+    platform: linux/amd64
     volumes:
       - webgrind_data:/tmp
     environment:


### PR DESCRIPTION
Fixes error with ARM 
```
 ⠧ webgrind Pulling                                                                                                            3.7s 
no matching manifest for linux/arm64/v8 in the manifest list entries
```